### PR TITLE
Prevent nametag from being consumed when unoptimising

### DIFF
--- a/src/main/java/me/xginko/villageroptimizer/modules/optimization/OptimizeByNametag.java
+++ b/src/main/java/me/xginko/villageroptimizer/modules/optimization/OptimizeByNametag.java
@@ -139,6 +139,11 @@ public class OptimizeByNametag extends VillagerOptimizerModule implements Listen
                 if (!unOptimizeEvent.callEvent()) return;
                 wrapped.setOptimizationType(OptimizationType.NONE);
 
+                if (!consume_nametag) {
+                    player.getInventory().addItem(usedItem.asOne());
+                    player.updateInventory();
+                }
+
                 if (notify_player) {
                     VillagerOptimizer.getLang(player.locale()).nametag_unoptimize_success
                             .forEach(line -> KyoriUtil.sendMessage(player, line));


### PR DESCRIPTION
Prevent name tag from being consumed when unoptimising villagers, if enabled.